### PR TITLE
Автоматическое создание файла конфигурации -nointeractive

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,6 @@ ls /sys/class/net
 ```
 
 ## Неинтерактивный режим (conf.env)
-
-Создайте файл `conf.env`:
-
-```bash
-strategy=general.bat
-interface=enp0s3
-gamefilter=true
-```
-
 Запуск:
 ```bash
 sudo bash main_script.sh -nointeractive


### PR DESCRIPTION
Очень сомнительно было что конфигурационный файл нужно было писать самому
Что сделано:

1. Переписан `load_config`, в случае отсутствия конфигурационного файла он не падает а вызывает `first_nointeractive_handler`, тот записывает данные в conf.env а затем скрипт запускается в -nointeractive штатном режиме
2. Добавлен `first_nointeractive_handler`, создает конфигурационный файл, записывает туда данные из функций `gamefilter_ask`, `select_strategy` и `setup_interface`
3. Gamefilter интерактивный вопрос вынесен в функцию `gamefilter_ask` во избежание повтора кода
4. Выбор стратегии вынесен в функцию `select_strategy` во избежание повтора кода
5. Выбор интерфейса вынесен в функцию `setup_interface` во избежание повтора кода
6. Иные изменения в упомянутых функциях, не касающиеся основной логики скрипта, а лишь дополняющие текущее состояние
7. Изменен Readme ведь вручную конфиг создавать более не требуется

AI использован НЕ был