### PR TITLE
Ошибка не выдачи библиотеки через command -v с отсутствием рута

### DIFF
--- a/src/lib/common.sh
+++ b/src/lib/common.sh
@@ -40,7 +40,7 @@ handle_error() {
 check_dependencies() {
     local deps=("git" "nft" "grep" "sed" "curl")
     for dep in "${deps[@]}"; do
-        if ! elevate which "$dep"; then
+        if ! elevate sh -c command -v "$dep" >/dev/null 2>&1; then
             handle_error "Не установлена утилита $dep"
         fi
     done

--- a/src/lib/download.sh
+++ b/src/lib/download.sh
@@ -82,6 +82,8 @@ download_zapret_release() {
     local archive="zapret-${tag}.tar.gz"
     local url="https://github.com/${ZAPRET_REPO}/releases/download/${tag}/${archive}"
     local tmp="/tmp/${archive}"
+    
+    elevate rm -rf "$tmp"
 
     log "Скачивание zapret: $url" >&2
     curl -fL "$url" -o "$tmp" || handle_error "Ошибка при скачивании zapret"
@@ -117,6 +119,7 @@ extract_nfqws_binary() {
 download_nfqws() {
     local version="${1:-latest}"
     local out_dir="${BASE_DIR:-$(dirname "$NFQWS_PATH")}"
+    
 
     log "Скачивание nfqws (версия: $version)..." >&2
 


### PR DESCRIPTION
1. command -v теперь вызывается с elevate оборачиваясь в sh
2. Теперь перед скачиванием zapret репозитория удаляется старый из /tmp при наличии(например человек пытался скачать оригинальный репозиторий перед этим)