### PR TITLE
Исправление генерации сервиса OpenRC

### DIFF
--- a/src/init-backends/openrc.sh
+++ b/src/init-backends/openrc.sh
@@ -65,6 +65,7 @@ directory="\$HOMEDIR"
 kill_mode="mixed"
 extra_commands="logs"
 
+LOG_FILE="$LOG_FILE"
 output_log="$LOG_FILE"
 error_log="$LOG_FILE"
 


### PR DESCRIPTION
Сервис OpenRC генерировался без переменной LOG_FILE, которая ему нужна, из за чего при попытке запуска он выдавал ошибку.

До:
```
1. Запустить (без установки сервиса)
2. Управление сервисом
3. Изменить конфигурацию
4. Управление зависимостями
5. Управление desktop ярлыком
6. Настроить работу без пароля
7. Сменить режим ipset [Текущий - Any (Весь траффик)]
0. Выход
Выберите действие: 2
Обнаружена система: openrc
Статус: Сервис не установлен.

1. Установить и запустить сервис
0. Назад
Выберите действие: 1
Создание openrc сервиса для автозагрузки...
 * service zapret_discord_youtube added to runlevel default
 * Caching service dependencies ...                                                                                                                                                    [ ok ]
 * LOG_FILE не задан!
 * ERROR: zapret_discord_youtube failed to start
```

После:
```
./service.sh service remove
./service.sh service install
[sudo] пароль для bob: 
Обнаружена система: openrc
Удаление сервиса...
 * WARNING: zapret_discord_youtube is already stopped
 * service zapret_discord_youtube deleted from runlevel default
Сервис удален.
Обнаружена система: openrc
Создание openrc сервиса для автозагрузки...
 * service zapret_discord_youtube added to runlevel default
 * Caching service dependencies ...                                                                                                                                                    [ ok ]
 * Starting zapret_discord_youtube ...                                                                                                                                                 [ ok ]
Сервис успешно установлен и запущен.

```