### PR TITLE
Bat файлы не переименовываются, если запускать скрипт из другой директории

### DIFF
--- a/src/rename_bat.sh
+++ b/src/rename_bat.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Перейти в корневую директорию
+cd "$(dirname "$0")/.."
+
 # Директория для обработки
 TARGET_DIR="zapret-latest"
 


### PR DESCRIPTION
Перед работой скрипта директория меняется на корневую