### PR TITLE
Патч RCE уязвимости

### DIFF
--- a/src/lib/common.sh
+++ b/src/lib/common.sh
@@ -373,13 +373,19 @@ start_nfqws() {
     stop_nfqws
     cd "$REPO_DIR" || handle_error "Не удалось перейти в директорию $REPO_DIR"
 
-    local full_params=""
+    local full_params=(
+        "$NFQWS_PATH"
+        --daemon
+        --dpi-desync-fwmark="$NFT_MARK"
+        --qnum="$NFT_QUEUE_NUM"
+    )
+
     for params in "${nfqws_params[@]}"; do
-        full_params="$full_params $params"
+        full_params+=($params)
     done
 
-    debug_log "Запуск nfqws с параметрами: $NFQWS_PATH --daemon --dpi-desync-fwmark=$NFT_MARK --qnum=$NFT_QUEUE_NUM $full_params"
-    eval "elevate $NFQWS_PATH --daemon --dpi-desync-fwmark=$NFT_MARK --qnum=$NFT_QUEUE_NUM $full_params" ||
+    debug_log "Запуск NFQWS с параметрами: ${full_params[@]}"
+    elevate "${full_params[@]}" ||
         handle_error "Ошибка при запуске nfqws"
 }
 


### PR DESCRIPTION
Файл `lib/common.sh` Строка `eval "elevate $NFQWS_PATH --daemon --dpi-desync-fwmark=$NFT_MARK --qnum=$NFT_QUEUE_NUM $full_params" || handle_error "Ошибка при запуске nfqws"` парсит аргументы из $full_params, который в свою очередь парсит аргументы из `nfqws_params` а он парсит аргументы уже из файла
Любой злоумышленник может спрятать в конфигурации код, сам Flowseal или контрибтюторы оригинального zapret-discord-youtube, а также в кастомных конфигурациях
Выглядит это примерно так - `--filter-tcp=443 --dpi-desync=fake; touch /tmp/example # --new`
При запуске конфигурации с такой строкой файл создастся
Это не опасно при должной проверки поступающих файлов конфигурации (Как я уже спрашивал)

# Фикс
```bash
local full_params=(
        "$NFQWS_PATH"
        --daemon
        --dpi-desync-fwmark="$NFT_MARK"
        --qnum="$NFT_QUEUE_NUM"
    )

    for params in "${nfqws_params[@]}"; do
        full_params+=($params)
    done

    debug_log "Запуск NFQWS с параметрами: ${full_params[@]}"
    elevate "${full_params[@]}" ||
        handle_error "Ошибка при запуске nfqws"
```
Аргументы вкладываются в список что заставляет их быть частью одной команды и в случае если в конфигурации не флаг программа упадет с ошибкой
