### PR TITLE
Enhance security and reliability of nftables handling

### DIFF
--- a/auto_tune_youtube.sh
+++ b/auto_tune_youtube.sh
@@ -72,14 +72,48 @@ get_name_from_entry() {
 
 stop_zapret() {
     "$SERVICE_SCRIPT" kill 2>/dev/null
-    sleep 1
+
+    local elapsed=0
+    while [[ $elapsed -lt 5 ]]; do
+        if ! nft list tables 2>/dev/null | grep -q "zapretunix"; then
+            return 0
+        fi
+        sleep 1
+        (( elapsed++ ))
+    done
+    # Не страшно если не дождались - следующий запуск всё равно очищает таблицу
+    return 0
 }
+
+READY_TIMEOUT=10  # максимум секунд ожидания готовности
 
 run_strategy() {
     local strategy_name="$1"
-    # Запускаем через service.sh run с параметрами
+
     "$SERVICE_SCRIPT" run -s "$strategy_name" -i any >/dev/null 2>&1 &
-    sleep "$WAIT_TIME"
+    local bg_pid=$!
+
+    # Ждём либо пока nftables применится, либо пока процесс не упадёт
+    local elapsed=0
+    while [[ $elapsed -lt $READY_TIMEOUT ]]; do
+        # Процесс уже упал - стратегия не запустилась
+        if ! kill -0 "$bg_pid" 2>/dev/null; then
+            return 1
+        fi
+
+        # nftables-таблица появилась - правила применены
+        if nft list tables 2>/dev/null | grep -q "zapretunix"; then
+            # Ещё секунда чтобы nfqws успел подняться после nft
+            sleep 1
+            return 0
+        fi
+
+        sleep 1
+        (( elapsed++ ))
+    done
+
+    # Таймаут - что-то пошло не так
+    return 1
 }
 
 # Запустить service.sh run с стратегией (не в фоне, для постоянного использования)
@@ -269,7 +303,11 @@ for ((i=1; i<=MAX_STRATEGY; i++)); do
     name=$(get_strategy_name $i)
     printf "  ${BOLD}[%2d/%d]${NC} %-40s " "$i" "$MAX_STRATEGY" "$name"
 
-    run_strategy "$name" >/dev/null 2>&1
+    if ! run_strategy "$name" >/dev/null 2>&1; then
+        echo -e "${RED}[!] Стратегия не запустилась, пропускаем${NC}"
+        ((FAILED_COUNT++))
+        continue
+    fi
     ((TESTED_COUNT++))
     
     result=$(test_strategy)

--- a/src/lib/common.sh
+++ b/src/lib/common.sh
@@ -46,6 +46,13 @@ check_dependencies() {
             handle_error "Не установлена утилита $dep"
         fi   
     done
+
+    # Проверка модуля ядра nfnetlink_queue (необходим для nfqws)
+    if command -v lsmod >/dev/null 2>&1; then
+        if ! lsmod | grep -q nfnetlink_queue; then
+            log "Предупреждение: модуль ядра nfnetlink_queue не загружен. nfqws может не работать."
+        fi
+    fi
 }
 
 # -----------------------------------------------------------------------------

--- a/src/lib/common.sh
+++ b/src/lib/common.sh
@@ -63,11 +63,24 @@ check_conf_file() {
 
     local required_fields=("interface" "gamefilter" "strategy")
     for field in "${required_fields[@]}"; do
-        if ! grep -q "^${field}=[^[:space:]]" "$conf_file"; then
+        if ! grep -qE "^${field}=.+" "$conf_file"; then
             return 1
         fi
     done
     return 0
+}
+
+# Безопасное чтение одного значения из conf.env
+# Использование: _read_conf_value "ключ" "/path/to/conf.env"
+_read_conf_value() {
+    local key="$1"
+    local conf_file="$2"
+
+    # Ищем строки вида key=value, игнорируем комментарии и пустые строки
+    # Значение может содержать пробелы, но не переводы строк
+    grep -E "^${key}=[^\n]*" "$conf_file" \
+        | head -n1 \
+        | cut -d= -f2-
 }
 
 # Загрузка конфигурации из файла
@@ -78,10 +91,35 @@ load_config() {
         handle_error "Файл конфигурации $conf_file не найден"
     fi
 
-    source "$conf_file"
+    # Читаем каждое поле явно - без выполнения файла
+    interface=$(_read_conf_value "interface" "$conf_file")
+    gamefilter=$(_read_conf_value "gamefilter" "$conf_file")
+    strategy=$(_read_conf_value "strategy" "$conf_file")
 
     if [[ -z "$interface" ]] || [[ -z "$gamefilter" ]] || [[ -z "$strategy" ]]; then
         handle_error "Отсутствуют обязательные параметры в конфигурационном файле"
+    fi
+
+    # Дополнительная валидация значений
+    _validate_config
+}
+
+_validate_config() {
+    # gamefilter должен быть строго true или false
+    if [[ "$gamefilter" != "true" && "$gamefilter" != "false" ]]; then
+        handle_error "Недопустимое значение gamefilter='$gamefilter'. Допустимо: true, false"
+    fi
+
+    # interface не должен содержать спецсимволов (защита от инъекций в nft-команды)
+    if [[ -n "$interface" && "$interface" != "any" ]]; then
+        if [[ ! "$interface" =~ ^[a-zA-Z0-9_@.-]+$ ]]; then
+            handle_error "Недопустимое имя интерфейса: '$interface'"
+        fi
+    fi
+
+    # strategy - только имя файла, без путей и спецсимволов
+    if [[ "$strategy" =~ [/\\] ]] || [[ "$strategy" =~ \.\. ]]; then
+        handle_error "Недопустимое имя стратегии: '$strategy'. Не должно содержать пути"
     fi
 }
 


### PR DESCRIPTION
Что поменял:

conf.env больше не выполняется как shell-скрипт, значения парсятся явно

auto_tune ждёт подтверждения от nftables вместо фиксированного sleep 2

предупреждение если модуль nfnetlink_queue не загружен в ядре