### PR TITLE
fix(runit): remove manual runsv termination

### DIFF
--- a/src/init-backends/runit.sh
+++ b/src/init-backends/runit.sh
@@ -90,12 +90,12 @@ restart_service() {
 
 # Функция удаления сервиса
 remove_service() {
-    echo "Остановка и удаление сервиса"
+    echo "Остановка и удаление сервиса..."
 
     elevate sv down "$SERVICE_NAME" 2>/dev/null || true
     sleep 1
     elevate rm -rf "$SERVICE_DIR"
     elevate rm -f "$SCAN_DIR/$SERVICE_NAME"
 
-    echo "Сервис полностью удален."
+    echo "Сервис полностью удалён."
 }

--- a/src/init-backends/runit.sh
+++ b/src/init-backends/runit.sh
@@ -90,19 +90,12 @@ restart_service() {
 
 # Функция удаления сервиса
 remove_service() {
-    echo "Остановка и удаление сервиса..."
+    echo "Остановка и удаление сервиса"
 
-    if [[ -d "$SERVICE_DIR" ]]; then
-        elevate sv down "$SERVICE_NAME" 2>/dev/null || true
-        sleep 2
-    fi
-
+    elevate sv down "$SERVICE_NAME" 2>/dev/null || true
+    sleep 1
     elevate rm -rf "$SERVICE_DIR"
-    elevate rm "$SCAN_DIR/$SERVICE_NAME"
+    elevate rm -f "$SCAN_DIR/$SERVICE_NAME"
 
-    if pgrep -f "runsv $SERVICE_NAME" >/dev/null; then
-        elevate pkill -f "runsv $SERVICE_NAME"
-    fi
-
-    echo "Сервис полностью удалён."
+    echo "Сервис полностью удален."
 }


### PR DESCRIPTION
Удалено ручное завершение runsv через pkill при удалении сервиса.

Сервис теперь  останавливается через sv down. Это делает реализацию более идиоматичной для runit и соответствует рекомендациям из документации Void Linux.  pkill мог потенциально задеть посторонние процессы при определенных обстоятельтвах.